### PR TITLE
Remove leftover `musInfo.loopPoint` variable from RSDKv3

### DIFF
--- a/Nexus/Audio.cpp
+++ b/Nexus/Audio.cpp
@@ -232,7 +232,7 @@ void ProcessMusicStream(Sint32 *stream, size_t bytes_wanted)
                 if (bytes_read == 0) {
                     // We've reached the end of the file
                     if (musInfo.trackLoop) {
-                        ov_pcm_seek(&musInfo.vorbisFile, musInfo.loopPoint);
+                        ov_pcm_seek(&musInfo.vorbisFile, 0);
                         continue;
                     }
                     else {

--- a/Nexus/Audio.hpp
+++ b/Nexus/Audio.hpp
@@ -129,7 +129,6 @@ inline void freeMusInfo()
         ov_clear(&musInfo.vorbisFile);
         musInfo.buffer    = nullptr;
         musInfo.trackLoop = false;
-        musInfo.loopPoint = 0;
         musInfo.loaded    = false;
         musicStatus       = MUSIC_STOPPED;
 


### PR DESCRIPTION
Due to how this decomp's origins began as a modified version of RSDKv3's Decompilation, it would be natural that some things would slip through the cracks, none more apparent than how `musInfo.loopPoint` remains leftover in the Audio source files of the RSDKv2 decomps, despite them not existing in the *actual* RSDKv2.
With that said, this pull request aims to fix this minor oversight by making sure it's consistent as possible without it leading to either a crash or a compile error when trying to compile the game in SDL1.